### PR TITLE
Add option to show entity icon in label

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 The main idea of this card is to show the energy consumption of your devices as a percentage of the **main entity** (your entity for tracking whole **house consumption**).
 
 
-The card is designed to resemble the Home Assistant **Energy panel** style. The **auto color** option will use the colors in the same order as the energy panel. 
+The card is designed to resemble the Home Assistant **Energy panel** style. The **auto color** option will use the colors in the same order as the energy panel.
 
 <div id="installation">
 <h1> Installation</h1>
@@ -156,7 +156,7 @@ entities:
     state_content:
       - name
       - state
-      - percentage 
+      - percentage
     line_state_content:
       - percentage
   - entity: sensor.plug_1_power
@@ -173,7 +173,7 @@ There are a lot of settings you can customize your sensors with:
 
 | Setting                        |         type          |           default            |                                         example                                          | description                                                                                                                                |
 |--------------------------------|:---------------------:|:----------------------------:|:----------------------------------------------------------------------------------------:|:-------------------------------------------------------------------------------------------------------------------------------------------|
-| `entity`                       |       entityID        |         *!required*          |                                       sensor.power                                       | You can specify the entity_id here as well.                                                                                                | 
+| `entity`                       |       entityID        |         *!required*          |                                       sensor.power                                       | You can specify the entity_id here as well.                                                                                                |
 | `title`                        |        string         |            *none*            |                                    Power Consumption                                     | The title of the Card (font_size: 2rem)                                                                                                    |
 | `subtitle`                     |        string         |            *none*            |                                           Glow                                           | Text in gray below the title (font_size: 1rem)                                                                                             |
 | `title_position`               |     PositionType      |          `top-left`          |                                           left                                           | Position of the title [see examples](#position)                                                                                            |
@@ -193,7 +193,7 @@ There are a lot of settings you can customize your sensors with:
 | `line_text_size`               |        number         |             `1`              |                                           1.5                                            | Font size of the state content in the line (in rem)                                                                                        |
 | `line_text_style`              |     TextStyleType     |            *none*            |                                     ['shadow-hard']                                      | Text style of the State content inside the Line [see examples and hierarchy](#style)                                                       |
 | `line_text_overflow`           |   TextOverflowType    |          `tooltip`           |                                           fade                                           | What happens when the text in the line overflows [see examples](#overflow)                                                                 |
-| `color`                        |       ColorType       |       *primary-color*        |                                         #00aafa                                          | The color of the gauge. And the untracked legend.                                                                                          |                                                                 
+| `color`                        |       ColorType       |       *primary-color*        |                                         #00aafa                                          | The color of the gauge. And the untracked legend.                                                                                          |
 | `color_bg`                     |       ColorType       | *secondary-background-color* |                                       [40, 40, 40]                                       | The background color of the gauge. Only visible if the gauge is not filled (max is entity).                                                |
 | `tap_action`                   |     Action Config     |         *more-info*          | [Configuration](https://www.home-assistant.io/lovelace/actions/#configuration-variables) | Single tap action for item.                                                                                                                |
 | `hold_action`                  |     Action Config     |         *more-info*          | [Configuration](https://www.home-assistant.io/lovelace/actions/#configuration-variables) | Hold action for item.                                                                                                                      |
@@ -241,7 +241,7 @@ The types are used in the configuration. The type is used to define what kind of
 | UntrackedStateContent | Array of any: `state`, `name`, `percentage`                                                                                                                                                                                                                                                                                                                         |
 |   StatisticsPeriod    | Single: `5minute`, `hour`, `day`, `week`, `month`                                                                                                                                                                                                                                                                                                                   |
 |  StatisticsFunction   | Single: `max`, `mean`, `min`, `state`, `sum`, `change`                                                                                                                                                                                                                                                                                                              |
-|     StateContent      | Array of any: `state`, `name`, `last_changed`, `last_updated`, `percentage`                                                                                                                                                                                                                                                                                         |
+|     StateContent      | Array of any: `state`, `name`, `last_changed`, `last_updated`, `percentage`, `icon`                                                                                                                                                                                                                                                                                     |
 
 </div>
 
@@ -259,7 +259,7 @@ The only required field is `entity`. The rest of the fields are optional. Color 
 
 | Setting              |     type      |     default      |                                         example                                          | description                                                                                                                                          |
 |----------------------|:-------------:|:----------------:|:----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `entity`             |   entityID    |   *!required*    |                                   sensor.plug_0_power                                    | You can specify the entity_id here as well.                                                                                                          | 
+| `entity`             |   entityID    |   *!required*    |                                   sensor.plug_0_power                                    | You can specify the entity_id here as well.                                                                                                          |
 | `name`               |    string     |      *none*      |                                          Plug 0                                          | The name of the entity to be displayed in the legend.                                                                                                |
 | `icon`               |    string     |      *none*      |                                        mdi:flash                                         | Display an icon instead of the colored circle. (icon will also be colored) [example](#icon)                                                          |
 | `color`              |   ColorType   |      `auto`      |                                           auto                                           | The color of the gauge and legend. (auto: Home Assistant Energy panel - the same order)                                                              |
@@ -272,7 +272,7 @@ The only required field is `entity`. The rest of the fields are optional. Color 
 | `tap_action`         | Action Config |   *more-info*    | [Configuration](https://www.home-assistant.io/lovelace/actions/#configuration-variables) | Single tap action for item.                                                                                                                          |
 | `hold_action`        | Action Config |   *more-info*    | [Configuration](https://www.home-assistant.io/lovelace/actions/#configuration-variables) | Hold action for item.                                                                                                                                |
 | `double_tap_action`  | Action Config |      *none*      | [Configuration](https://www.home-assistant.io/lovelace/actions/#configuration-variables) | Double tap action for item.                                                                                                                          |
-<p> 
+<p>
 
 </div>
 
@@ -359,7 +359,7 @@ entities:
 
 ### Normal usage ( how I use it )
 
-Mainly using the default settings. 
+Mainly using the default settings.
 I am using the automatic color option, and I have the entities in the same order as I have them in the Home Assistant Energy panel.
 
 <img src="https://github.com/Tomer27cz/energy-line-gauge/raw/main/.github/img/examples/normal.png" alt="Normal Usage">
@@ -554,6 +554,7 @@ The position of the text in the line is set by `line_text_position`. Options are
 | `last_changed` | The last time the entity changed state.                      | 6 seconds ago |
 | `last_updated` | The last time the entity was updated.                        | 6 seconds ago |
 | `percentage`   | The percentage of the entity in respect to the main entity.  |      55%      |
+| `icon`         | Specified in config or if not the `icon` attribute.          | mdi:lightbulb |
 
 <img src="https://github.com/Tomer27cz/energy-line-gauge/raw/main/.github/img/examples/state_content.png" alt="State Content">
 
@@ -618,7 +619,7 @@ untracked_line_state_content:
 | `bottom-left` | `bottom-center` | `bottom-right` |
 
 
-       
+
 
 </div>
 
@@ -660,7 +661,7 @@ Some entities only support `mean`, `min` and `max` (For example `sensor.plug_1_p
 
 <hr/>
 
-**If you find a Bug or have some suggestions, let me know <a href="https://github.com/Tomer27cz/energy-line-gauge/issues">here</a>! I'm happy about every feedback.** 
+**If you find a Bug or have some suggestions, let me know <a href="https://github.com/Tomer27cz/energy-line-gauge/issues">here</a>! I'm happy about every feedback.**
 
 **Contributions are welcome!**
 

--- a/src/editor/item-editor.ts
+++ b/src/editor/item-editor.ts
@@ -52,6 +52,7 @@ export class ItemEditor extends LitElement {
                   ["last_changed", this.hass.localize("ui.components.state-content-picker.last_changed")], // Last Changed
                   ["last_updated", this.hass.localize("ui.components.state-content-picker.last_updated")], // Last Updated
                   ["percentage", this.hass.localize("ui.panel.lovelace.editor.edit_section.settings.column_span") + " [%]"], // Width [%]
+                  ["icon", this.hass.localize("ui.panel.lovelace.editor.card.generic.icon")], // Icon
                 ],
                 name: "state_content",
                 required: false,
@@ -65,6 +66,7 @@ export class ItemEditor extends LitElement {
                   ["last_changed", this.hass.localize("ui.components.state-content-picker.last_changed")], // Last Changed
                   ["last_updated", this.hass.localize("ui.components.state-content-picker.last_updated")], // Last Updated
                   ["percentage", this.hass.localize("ui.panel.lovelace.editor.edit_section.settings.column_span") + " [%]"], // Width [%]
+                  ["icon", this.hass.localize("ui.panel.lovelace.editor.card.generic.icon")], // Icon
                 ],
                 name: "line_state_content",
                 required: false,

--- a/src/energy-line-gauge.ts
+++ b/src/energy-line-gauge.ts
@@ -234,7 +234,7 @@ export class EnergyLineGauge extends LitElement {
     }
 
     return html`
-      <ha-card 
+      <ha-card
         .header=${this._config.header}
         @action=${this._handleAction}
         .actionHandler=${actionHandler({
@@ -293,7 +293,7 @@ export class EnergyLineGauge extends LitElement {
           const stateObj: HassEntity = this.hass.states[device.entity];
           const state = this._calcState(stateObj, device.multiplier);
           const cutoff = device.cutoff ?? this._config.cutoff ?? 0;
-          
+
           if (state <= cutoff && !this._config.legend_all) {return html``;}
 
           // noinspection HtmlUnknownAttribute
@@ -304,16 +304,16 @@ export class EnergyLineGauge extends LitElement {
                 hasHold: hasAction(device.hold_action),
                 hasDoubleClick: hasAction(device.double_tap_action),
               })}
-              title="${this._entityName(device, stateObj)}" 
+              title="${this._entityName(device, stateObj)}"
               id="legend-${device.entity.replace('.', '-')}"
             >
-              ${device.icon ? 
-                  html`<ha-icon style="color:${toHEX(device.color)}" icon="${device.icon}"></ha-icon>` : 
+              ${device.icon ?
+                  html`<ha-icon style="color:${toHEX(device.color)}" icon="${device.icon}"></ha-icon>` :
                   html`<div class="bullet" style="background-color:${toHEX(device.color) + "7F"};border-color:${toHEX(device.color)};"></div>`
               }
               <div class="label" style="font-size: ${textSize}rem; ${textStyle}">${this._entityLabel(device, stateObj, false, state)}</div>
             </li>`;
-        })}  
+        })}
         ${this._createUntrackedLegend(textStyle, textSize)}
       </ul>
     </div>`
@@ -348,9 +348,9 @@ export class EnergyLineGauge extends LitElement {
 
       // noinspection HtmlUnknownAttribute
       return html`
-      <div 
-        id="line-${device.entity.replace(".", "-")}" 
-        class="device-line" 
+      <div
+        id="line-${device.entity.replace(".", "-")}"
+        class="device-line"
         style="background-color: ${toHEX(device.color)}; width: ${width}%;"
         @action=${(ev: ActionHandlerEvent) => this._handleAction(ev, device)}
         .actionHandler=${actionHandler({
@@ -359,11 +359,11 @@ export class EnergyLineGauge extends LitElement {
       })}
       >
         ${displayLineState ? html`
-          <div 
-            class="device-line-label line-text-position-${this._config.line_text_position ?? "left"}" 
+          <div
+            class="device-line-label line-text-position-${this._config.line_text_position ?? "left"}"
             style="
-              color: rgba(${lineTextColor}); 
-              font-size: ${this._config.line_text_size ?? 1}rem; 
+              color: rgba(${lineTextColor});
+              font-size: ${this._config.line_text_size ?? 1}rem;
               ${overflowStyle}
               ${textStyle}
           ">
@@ -384,10 +384,10 @@ export class EnergyLineGauge extends LitElement {
       ${deviceLines}
       ${displayUntrackedLine ? html`
         <div class="untracked-line" style="width: ${untrackedWidth}%">
-          <div 
-            class="device-line-label line-text-position-${this._config.line_text_position ?? "left"}" 
+          <div
+            class="device-line-label line-text-position-${this._config.line_text_position ?? "left"}"
             style="
-              color: rgba(${untrackedTextColor}); 
+              color: rgba(${untrackedTextColor});
               font-size: ${this._config.line_text_size ?? 1}rem;
               ${untrackedStyle}
         ">
@@ -477,6 +477,10 @@ export class EnergyLineGauge extends LitElement {
     if (device.name) {return device.name;}
     return stateObj.attributes.friendly_name || device.entity.split('.')[1];
   }
+  private _entityIcon(device: ELGEntity, stateObj: HassEntity): string {
+    if (device.icon) {return device.icon;}
+    return stateObj.attributes.icon || '';
+  }
   private _entityLabel(device: ELGEntity, stateObj: HassEntity, line?: boolean, calculatedState?: number,): TemplateResult | string | undefined {
     if (line) {
       if (!device.line_state_content || device.line_state_content.length === 0) {return;}
@@ -501,6 +505,7 @@ export class EnergyLineGauge extends LitElement {
         case "last_changed": return timeTemplate(stateObj.last_changed);
         case "last_updated": return timeTemplate(stateObj.last_updated);
         case "percentage": return html`${this._entitiesWidth[device.entity].toFixed(0)}%${dot}`;
+        case "icon": return html`<ha-icon icon="${this._entityIcon(device, stateObj)}"></ha-icon>`;
         default: return html`${value}${dot}`;
       }
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,7 +111,7 @@ export const POSITION_TYPES = ['left', 'right', 'none', 'top-left', 'top-middle'
 export const LINE_POSITION_TYPES = ['left', 'right', 'none', 'center', 'top-left', 'top-right', 'top-center', 'bottom-left', 'bottom-right', 'bottom-center'] as const;
 export const LEGEND_ALIGNMENT_TYPES = ['left', 'right', 'center', 'space-around', 'space-between', 'space-evenly'] as const;
 
-export const STATE_CONTENT_TYPES = ['name', 'state', 'last_changed', 'last_updated', 'percentage'] as const;
+export const STATE_CONTENT_TYPES = ['name', 'state', 'last_changed', 'last_updated', 'percentage', 'icon'] as const;
 export const UNTRACKED_STATE_CONTENT_TYPES = ['name', 'state', 'percentage'] as const;
 
 export const STATISTICS_PERIOD_TYPES = ['5minute', 'hour', 'day', 'week', 'month'] as const;


### PR DESCRIPTION
Hey, I discovered this card yesterday and it was something I've been wanting for ages. Thank you!

I wanted to be able to compactly see which section of the bar is which entity, so I've added the option to show the entity icon in the bar. It will either use the icon set in the config or the entity's own icon.

This is what it looks like:
![image](https://github.com/user-attachments/assets/4302a3f1-b471-4bae-849a-4eaa0e3ff08b)
